### PR TITLE
Explicitly enable Java 8 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,16 @@
           <artifactId>wildfly-maven-plugin</artifactId>
           <version>${version.org.wildfly.plugins}</version>
         </plugin>
+    
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Otherwise IDE's (like Eclipse) that honors your pom.xml will
configure your project to use Java 5 (maven default) and you will get compile
errors since you use Java 8 features.
